### PR TITLE
update: web側によるCORSを許可する設定を適用

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,2 +1,3 @@
 Django==5.0.1
 djangorestframework==3.14.0
+django-cors-headers==4.3.1

--- a/apps/api/routifyapiproject/routifyapiproject/settings.py
+++ b/apps/api/routifyapiproject/routifyapiproject/settings.py
@@ -27,10 +27,15 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+CORS_ORIGIN_WHITELIST = [
+    'http://localhost:3000',
+    'http://127.0.0.1:3000',
+]
 
 # Application definition
 
 INSTALLED_APPS = [
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -42,6 +47,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Web側から直接アクセスができるように、localhost:3000からのCORS権限を解除して、apiを取得できるようにしました。